### PR TITLE
fixes #42 added Yoga 3 14 to the list of hardware which doesn't have …

### DIFF
--- a/yoga_laptop/Makefile
+++ b/yoga_laptop/Makefile
@@ -6,12 +6,15 @@ PWD := $(shell pwd)
 ifeq "$(NAME)" "Fedora"
 KDIR := /usr/src/kernels/$(shell uname -r)
 MODNAME := ideapad-laptop.ko
+UDEVDIR := /usr/lib/udev/hwdb.d
 else ifeq ("$(NAME)",$(filter "$(NAME)","arch" "Antergos"))
 KDIR := /usr/lib/modules/$(shell uname -r)/build
 MODNAME := ideapad-laptop.ko.gz
+UDEVDIR := /usr/lib/udev/hwdb.d
 else
 KDIR := /usr/src/linux-headers-$(shell uname -r)
 MODNAME := ideapad-laptop.ko
+UDEVDIR := /lib/udev/hwdb.d
 endif
 MODDIR := /lib/modules/$(shell uname -r)/kernel/drivers/platform/x86
 
@@ -36,7 +39,7 @@ install-driver:
 	install --owner=root --group=root --mode=644 $(MODNAME) $(MODDIR)
 
 install-keys:
-	install --owner=root --group=root --mode=644 90-yoga-keyboard.hwdb /usr/lib/udev/hwdb.d
+	install --owner=root --group=root --mode=644 90-yoga-keyboard.hwdb $(UDEVDIR)
 	udevadm hwdb --update
 	cp -pr xkeycode /home/${LOGNAME}/.Xmodmap
 

--- a/yoga_laptop/ideapad-laptop.c
+++ b/yoga_laptop/ideapad-laptop.c
@@ -841,6 +841,13 @@ static struct dmi_system_id no_hw_rfkill_list[] = {
 			DMI_MATCH(DMI_PRODUCT_VERSION, "Lenovo Yoga 2"),
 		},
 	},
+	{
+		.ident = "Lenovo Yoga 3 14",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_PRODUCT_VERSION, "Lenovo Yoga 3 14"),
+		},
+	},
 	{}
 };
 


### PR DESCRIPTION
…any hardware wifi kill switch

Yoga 3 14 has kbd layout the same as a Yoga 2 and ubuntu 14.04 the wifi is similarly hardware disabled. The Makefile update is to account for the change in the hwdb.d location between Ubuntu and Fedora (which I guess is was the original target of the fix). 

I have tested it on this Laptop only, I would guess that more models may also apply but I added a specific model match because no other test platforms existed where I was sat, there could be other issues, the wifi is now working correctly however. 