### PR TITLE
Replace system() calls by direct libnotify library calls. 

### DIFF
--- a/sensors/Makefile
+++ b/sensors/Makefile
@@ -14,6 +14,7 @@ generic_buffer: generic_buffer.c iio_utils.h
 
 orientation: orientation.c iio_utils.h
 	cc orientation.c $(CFLAGS) -o orientation
+	cc orientation.c `pkg-config --cflags --libs libnotify` $(CFLAGS) -o orientation
 
 hinge: hinge.c iio_utils.h
 	cc hinge.c $(CFLAGS) -o hinge


### PR DESCRIPTION
This adds a dependency on libnotify-dev. If you don't like this, please remove the fork() call, or replace the system() call by a corresponding execl() call -- otherwise, you'll spawn a new thread for every new notification which is never killed.
Also, if the icons I chose don't work generically (they work on ubuntu+xfce, I did not test anything else), feel free to change them (though the previous values will have worked on even fewer systems *g*)