### PR TITLE
add digitizer rotation support to orientation

### DIFF
--- a/sensors/libs/config.h
+++ b/sensors/libs/config.h
@@ -31,6 +31,7 @@ extern "C" {
 
 		/* Orientation config*/
 		const char *or_touchScreenName;
+		const char *or_wacomPenName;
 
 		/* Light config */
 		// Top value used for scaling
@@ -45,6 +46,7 @@ extern "C" {
 
 		// Orientation
 		"ELAN Touchscreen",
+		"Wacom ISDv4 EC Pen stylus",
 
 		// Light
 		1400,


### PR DESCRIPTION
I've added the option to specify an other xinput device to get rotation of digitizer pen inputs working. The reason is, that at least the thinkpad yoga series has the option of a digitizer.

If a device does not have the default digitizer xinput device called "Wacom ISDv4 EC Pen stylus" ,orientation, or more precisely xinput, currently prints: "unable to find device Wacom ISDv4 EC Pen stylus". I'm not sure how to handle this correctly, because checking for the existence of the input device is hard to do cleanly and on the other hand adding a commandline flag to enable digitizer rotation adds unnecessary complexity for the user.

Do you have an idea what would be best to do?
