### PR TITLE
Add support for setting the orientation for multiple (up to 5) input …

### DIFF
--- a/sensors/libs/config.h
+++ b/sensors/libs/config.h
@@ -30,7 +30,7 @@ extern "C" {
 		const char* device_name;
 
 		/* Orientation config*/
-		const char *or_touchScreenName;
+		const char *or_touchScreenName[5];
 
 		/* Light config */
 		// Top value used for scaling
@@ -44,7 +44,7 @@ extern "C" {
 		"",
 
 		// Orientation
-		"ELAN Touchscreen",
+		{"ELAN Touchscreen", "", "", "", ""},
 
 		// Light
 		1400,


### PR DESCRIPTION
…devices.

This change allows the thinkpad helix 2 to rotate the touch and pen input devices by specifying `--touchscreen` multiple times, once for each device needing rotation. Here's an example, for my helix 2:

orientation --touchscreen="Wacom HID 5014 Finger touch" --touchscreen="Wacom HID 114 Pen stylus" --touchscreen="Wacom HID 114 Pen eraser"

I haven't tried #53, but at first blush, this seems to me like a more flexible and discoverable approach.