### PR TITLE
Add a udev rule file to set usable permissions of needed sysfs files

### DIFF
--- a/sensors/conf/10-orientation.rules
+++ b/sensors/conf/10-orientation.rules
@@ -1,0 +1,5 @@
+ATTR{name}=="accel_3d", RUN+="/usr/bin/find /sys/bus/iio/devices/$kernel/scan_elements -name in_*_en -execdir /bin/chmod 664 {} ; -execdir /bin/chgrp plugdev {} ;"
+ATTR{name}=="accel_3d", RUN+="/usr/bin/find /sys/bus/iio/devices/$kernel/buffer -name * -execdir /bin/chmod 664 {} ; -execdir /bin/chgrp plugdev {} ;"
+ATTR{name}=="accel_3d", RUN+="/usr/bin/find /sys/bus/iio/devices/$kernel/trigger -name current_trigger -execdir /bin/chmod 664 {} ; -execdir /bin/chgrp plugdev {} ;"
+ATTR{name}=="accel_3d", RUN+="/usr/bin/find /sys/bus/iio/devices/$kernel/ -name buffer -o -name trigger -o -name scan_elements -execdir /bin/chmod 775 {} ; -execdir /bin/chgrp plugdev {} ;"
+ATTR{name}=="accel_3d", SYMLINK+="%k", GROUP="plugdev", MODE="664"


### PR DESCRIPTION
This udev .rules file will set permissions of the needed sysfs files for accelerometer devices so that members of the `plugdev` group can run orientation. The way this is currently done in the makefile doesn't continue to work after a reboot.